### PR TITLE
GetActive() seg faults in very very corner case once in a while

### DIFF
--- a/local.go
+++ b/local.go
@@ -195,7 +195,7 @@ func (c *localCache) GetActive(k Key) (Value, error) {
 		return nil, err
 	}
 	en := c.cache.get(k, sum(k))
-	if ! en.getInvalidated() {
+	if en != nil && ! en.getInvalidated() {
 		return obj, nil
 	}
 	return nil, errors.New ("entry invalidated")
@@ -205,7 +205,7 @@ func (c *localCache) GetActive(k Key) (Value, error) {
 func (c *localCache) GetAllKeys() []interface{} {
 	keys := make([]interface{}, 0, c.cache.len())
 	c.cache.walk(func(en *entry) {
-		if ! en.getInvalidated() {
+		if en != nil && ! en.getInvalidated() {
 			keys = append(keys, en.key)
 		}
 	})
@@ -216,7 +216,7 @@ func (c *localCache) GetAllKeys() []interface{} {
 func (c *localCache) GetAllValues() []interface{} {
 	values := make([]interface{}, 0, c.cache.len())
 	c.cache.walk(func(en *entry) {
-		if ! en.getInvalidated() {
+		if en != nil && ! en.getInvalidated() {
 			values = append(values, en.getValue())
 		}
 	})
@@ -227,7 +227,7 @@ func (c *localCache) GetAllValues() []interface{} {
 func (c *localCache) GetAll() map[interface{}]interface{} {
 	var values = make(map[interface{}]interface{}, c.cache.len())
 	c.cache.walk(func(en *entry) {
-		if ! en.getInvalidated() {
+		if en != nil && ! en.getInvalidated() {
 			values[en.key] = en.getValue()
 		}
 	})


### PR DESCRIPTION
When a cache.Refresh() followed by GetActive() is done on a deleted object, it occasionally results in a segfault like below. The root cause is the entry is not validated before getInvalidated() is performed on it

panic: runtime error: invalid memory address or nil pointer dereference [recovered]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x15ce765]
....
....
/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/Comcast/goburrow-cache.(*entry).getInvalidated(...)
/Users/soggu464/go/pkg/mod/github.com/!comcast/goburrow-cache@v1.0.3/policy.go:90
github.com/Comcast/goburrow-cache.(*localCache).GetActive(0xc000110780,
/Users/soggu464/go/pkg/mod/github.com/!comcast/goburrow-cache@v1.0.3/local.go:198 +0x65…