### PR TITLE
GetActive() seg faults in very very corner case once in a while

### DIFF
--- a/local.go
+++ b/local.go
@@ -195,7 +195,7 @@ func (c *localCache) GetActive(k Key) (Value, error) {
 		return nil, err
 	}
 	en := c.cache.get(k, sum(k))
-	if ! en.getInvalidated() {
+	if en != nil && ! en.getInvalidated() {
 		return obj, nil
 	}
 	return nil, errors.New ("entry invalidated")


### PR DESCRIPTION
When a cache.Refresh() followed by GetActive() is done on a deleted object, it occasionally results in a segfault like below. The root cause is the entry is not validated before getInvalidated() is performed on it

panic: runtime error: invalid memory address or nil pointer dereference [recovered]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x15ce765]
....
....
/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/Comcast/goburrow-cache.(*entry).getInvalidated(...)
/Users/soggu464/go/pkg/mod/github.com/!comcast/goburrow-cache@v1.0.3/policy.go:90
github.com/Comcast/goburrow-cache.(*localCache).GetActive(0xc000110780,
/Users/soggu464/go/pkg/mod/github.com/!comcast/goburrow-cache@v1.0.3/local.go:198 +0x65…

$ go build -v
$ go test -v -bench . -race
=== RUN TestBloomFilter
--- PASS: TestBloomFilter (0.04s)
=== RUN TestSum
--- PASS: TestSum (0.00s)
=== RUN TestCache
--- PASS: TestCache (0.00s)
=== RUN TestMaximumSize
--- PASS: TestMaximumSize (0.22s)
=== RUN TestRemovalListener
--- PASS: TestRemovalListener (0.00s)
=== RUN TestClose
--- PASS: TestClose (0.00s)
=== RUN TestLoadingCache
--- PASS: TestLoadingCache (0.00s)
=== RUN TestCacheStats
--- PASS: TestCacheStats (0.00s)
=== RUN TestExpireAfterAccess
--- PASS: TestExpireAfterAccess (0.00s)
=== RUN TestExpireAfterWrite
--- PASS: TestExpireAfterWrite (0.00s)
=== RUN TestRefreshAterWrite
--- PASS: TestRefreshAterWrite (0.00s)
=== RUN TestGetIfPresentExpired
--- PASS: TestGetIfPresentExpired (0.00s)
=== RUN TestLoadingAsyncReload
--- PASS: TestLoadingAsyncReload (0.00s)
=== RUN TestLoadingRefresh
--- PASS: TestLoadingRefresh (0.00s)
=== RUN TestCloseMultiple
--- PASS: TestCloseMultiple (0.00s)
=== RUN TestLRU
--- PASS: TestLRU (0.00s)
=== RUN TestLRUWalk
--- PASS: TestLRUWalk (0.00s)
=== RUN TestSegmentedLRU
--- PASS: TestSegmentedLRU (0.00s)
=== RUN TestSLRUWalk
--- PASS: TestSLRUWalk (0.00s)
=== RUN TestCountMinSketch
--- PASS: TestCountMinSketch (0.00s)
=== RUN TestStatsCounter
--- PASS: TestStatsCounter (0.00s)
=== RUN TestTinyLFU
--- PASS: TestTinyLFU (0.00s)
goos: darwin
goarch: amd64
pkg: github.com/Comcast/goburrow-cache
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkSame
benchmark_test.go:95: total: 10000 (12.778221ms), hits: 9999 (99.99%), misses: 1 (0.01%), evictions: 0
benchmark_test.go:95: total: 933829 (1.321641988s), hits: 933826 (100.00%), misses: 3 (0.00%), evictions: 0
BenchmarkSame-12 933829 1415 ns/op 0 B/op 0 allocs/op
BenchmarkUniform
benchmark_test.go:95: total: 10000 (53.745031ms), hits: 4713 (47.13%), misses: 5287 (52.87%), evictions: 4423
benchmark_test.go:95: total: 218217 (815.208703ms), hits: 109108 (50.00%), misses: 109109 (50.00%), evictions: 101458
benchmark_test.go:95: total: 320929 (1.340897932s), hits: 160362 (49.97%), misses: 160567 (50.03%), evictions: 149627
BenchmarkUniform-12 320929 4182 ns/op 139 B/op 3 allocs/op
BenchmarkUniformLess
benchmark_test.go:95: total: 10000 (17.117974ms), hits: 9482 (94.82%), misses: 518 (5.18%), evictions: 0
benchmark_test.go:95: total: 674713 (1.330440863s), hits: 674200 (99.92%), misses: 513 (0.08%), evictions: 0
BenchmarkUniformLess-12 674713 1973 ns/op 27 B/op 0 allocs/op
BenchmarkCounter
benchmark_test.go:95: total: 10000 (73.527256ms), hits: 0 (0.00%), misses: 10000 (100.00%), evictions: 9428
benchmark_test.go:95: total: 161356 (1.249213548s), hits: 0 (0.00%), misses: 161356 (100.00%), evictions: 160789
BenchmarkCounter-12 161356 7747 ns/op 345 B/op 8 allocs/op
BenchmarkExponential
benchmark_test.go:95: total: 10000 (18.385768ms), hits: 9990 (99.90%), misses: 10 (0.10%), evictions: 0
benchmark_test.go:95: total: 649167 (1.022836388s), hits: 649153 (100.00%), misses: 14 (0.00%), evictions: 0
BenchmarkExponential-12 649167 1576 ns/op 0 B/op 0 allocs/op
BenchmarkZipf
benchmark_test.go:95: total: 10000 (46.818616ms), hits: 6693 (66.93%), misses: 3307 (33.07%), evictions: 2759
benchmark_test.go:95: total: 249249 (1.188586142s), hits: 180622 (72.47%), misses: 68627 (27.53%), evictions: 67536
BenchmarkZipf-12 249249 4772 ns/op 100 B/op 2 allocs/op
BenchmarkHotspot
benchmark_test.go:95: total: 10000 (40.920259ms), hits: 7987 (79.87%), misses: 2013 (20.13%), evictions: 1463
benchmark_test.go:95: total: 288040 (958.924426ms), hits: 239559 (83.17%), misses: 48481 (16.83%), evictions: 46996
benchmark_test.go:95: total: 360103 (1.197184314s), hits: 299741 (83.24%), misses: 60362 (16.76%), evictions: 58592
BenchmarkHotspot-12 360103 3327 ns/op 53 B/op 1 allocs/op
BenchmarkSumInt
BenchmarkSumInt-12 100000000 11.46 ns/op 0 B/op 0 allocs/op
BenchmarkSumString
BenchmarkSumString-12 49283776 26.69 ns/op 0 B/op 0 allocs/op
BenchmarkGetSame
BenchmarkGetSame-12 813745 1487 ns/op 0 B/op 0 allocs/op
BenchmarkCacheSegment
BenchmarkCacheSegment-12 3256952 362.1 ns/op 1 B/op 0 allocs/op
BenchmarkCountMinSketchReset
BenchmarkCountMinSketchReset-12 29988 39724 ns/op 0 B/op 0 allocs/op
PASS
ok github.com/Comcast/goburrow-cache 20.295s
goburrow-cache work_sree goburrow-cache)
$

